### PR TITLE
[feat] #8 TransactionView UI 구현

### DIFF
--- a/KB-STARBANKING/KB-STARBANKING/Presentation/NavigationView.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/NavigationView.swift
@@ -51,7 +51,7 @@ class NavigationView: UIView {
     }
     
     private func setStyle(){
-        self.backgroundColor = .color(.kbWhite)
+        self.backgroundColor = .kbWhite
     }
     
     private func setUI() {

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/NavigationView.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/NavigationView.swift
@@ -1,0 +1,92 @@
+//
+//  NavigationView.swift
+//  KB-STARBANKING
+//
+//  Created by 이세민 on 5/16/25.
+//
+
+import UIKit
+
+import SnapKit
+
+class NavigationView: UIView {
+    
+    private let navigationView = UIView()
+    
+    private let arrowBackIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .icArrowLeft
+        return imageView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "거래내역조회"
+        label.font = .font(.body1_16_light)
+        return label
+    }()
+    
+    private let homeIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .icHome
+        return imageView
+    }()
+    
+    private let menuIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .icMenu
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setStyle(){
+        self.backgroundColor = .color(.kbWhite)
+    }
+    
+    private func setUI() {
+        addSubview(navigationView)
+        navigationView.addSubviews(arrowBackIconView, titleLabel, homeIconView, menuIconView)
+    }
+    
+    private func setLayout() {
+        navigationView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+        
+        arrowBackIconView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(19)
+            $0.size.equalTo(24)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(arrowBackIconView.snp.trailing).offset(4)
+        }
+        
+        menuIconView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-19)
+            $0.size.equalTo(24)
+        }
+        
+        homeIconView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalTo(menuIconView.snp.leading).offset(-18)
+            $0.size.equalTo(24)
+        }
+    }
+}

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/TransactionViewController.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/TransactionViewController.swift
@@ -1,0 +1,80 @@
+//
+//  TransactionViewController.swift
+//  KB-STARBANKING
+//
+//  Created by 이세민 on 5/15/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class TransactionViewController: UIViewController {
+    
+    private let navigationView = NavigationView()
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    
+    private let accountInfo = AccountInfo()
+    private let primeRate = PrimeRate()
+    
+    private let emptyView = UIView().then {
+        $0.backgroundColor = .gray1
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    private func setStyle() {
+        view.backgroundColor = .kbWhite
+        scrollView.showsVerticalScrollIndicator = false
+    }
+    
+    private func setUI() {
+        view.addSubviews(navigationView, scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubviews(accountInfo, emptyView, primeRate)
+    }
+    
+    private func setLayout(){
+        navigationView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(-40)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+        
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(navigationView.snp.bottom).offset(18)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.width.equalTo(scrollView)
+        }
+        
+        accountInfo.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(329)
+        }
+        
+        emptyView.snp.makeConstraints {
+            $0.top.equalTo(accountInfo.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(11)
+        }
+        
+        primeRate.snp.makeConstraints {
+            $0.top.equalTo(emptyView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(524)
+            $0.bottom.equalToSuperview().inset(50)
+        }
+    }
+}

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/AccountInfo.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/AccountInfo.swift
@@ -15,7 +15,7 @@ class AccountInfo: UIView {
         let label = UILabel()
         label.text = "KB내맘대로적금"
         label.font = .font(.body1_16_light)
-        label.textColor = .color(.kbBlack)
+        label.textColor = .kbBlack
         return label
     }()
     
@@ -29,7 +29,7 @@ class AccountInfo: UIView {
         let label = UILabel()
         label.text = "016703-04-425292"
         label.font = .font(.title2_18_semibold)
-        label.textColor = .color(.kbBlack)
+        label.textColor = .kbBlack
         return label
     }()
     
@@ -55,7 +55,7 @@ class AccountInfo: UIView {
         label.text = "D-183"
         label.font = .font(.caption3_11_medium)
         label.textAlignment = .center
-        label.backgroundColor = .color(.gray8)
+        label.backgroundColor = .gray8
         label.textColor = .kbWhite
         label.clipsToBounds = true
         label.layer.cornerRadius = 11
@@ -64,10 +64,10 @@ class AccountInfo: UIView {
     
     private let expirationDateProgressView: UIProgressView = {
         let progressView = UIProgressView()
-        progressView.progressTintColor = .color(.yellow3)
-        progressView.trackTintColor = .color(.gray1)
+        progressView.progressTintColor = .yellow3
+        progressView.trackTintColor = .gray1
         progressView.progress = 0.3
-        progressView.layer.borderColor = UIColor.color(.gray4).cgColor
+        progressView.layer.borderColor = UIColor.gray4.cgColor
         progressView.layer.cornerRadius = 5
         progressView.layer.borderWidth = 1
         progressView.clipsToBounds = true
@@ -78,7 +78,7 @@ class AccountInfo: UIView {
         let label = UILabel()
         label.text = "신규일 2025.04.23"
         label.font = .font(.caption2_12_light)
-        label.textColor = .color(.gray6)
+        label.textColor = .gray6
         return label
     }()
     
@@ -86,16 +86,16 @@ class AccountInfo: UIView {
         let label = UILabel()
         label.text = "만기일 2025.10.23"
         label.font = .font(.caption2_12_light)
-        label.textColor = .color(.gray6)
+        label.textColor = .gray6
         return label
     }()
     
     private let depositButton: UIButton = {
         let button = UIButton()
         button.setTitle("입금", for: .normal)
-        button.setTitleColor(.color(.kbBlack), for: .normal)
+        button.setTitleColor(.kbBlack, for: .normal)
         button.titleLabel?.font = .font(.body3_14_light)
-        button.backgroundColor = .color(.gray3)
+        button.backgroundColor = .gray3
         button.layer.cornerRadius = 2
         button.clipsToBounds = true
         return button
@@ -104,9 +104,9 @@ class AccountInfo: UIView {
     private let expectClosingButton: UIButton = {
         let button = UIButton()
         button.setTitle("해지예상조회", for: .normal)
-        button.setTitleColor(.color(.kbBlack), for: .normal)
+        button.setTitleColor(.kbBlack, for: .normal)
         button.titleLabel?.font = .font(.body3_14_light)
-        button.backgroundColor = .color(.gray3)
+        button.backgroundColor = .gray3
         button.layer.cornerRadius = 2
         button.clipsToBounds = true
         return button
@@ -125,7 +125,7 @@ class AccountInfo: UIView {
     }
     
     private func setStyle(){
-        self.backgroundColor = .color(.kbWhite)
+        self.backgroundColor = .kbWhite
     }
     
     private func setUI() {
@@ -197,6 +197,7 @@ class AccountInfo: UIView {
         }
         
         depositButton.snp.makeConstraints {
+            $0.top.equalTo(expirationDateLabel.snp.bottom).offset(30)
             $0.top.equalTo(expirationDateLabel.snp.bottom).offset(30)
             $0.leading.equalToSuperview().offset(20)
             $0.width.equalTo(164)

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/AccountInfo.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/AccountInfo.swift
@@ -1,0 +1,213 @@
+//
+//  AccountInfo.swift
+//  KB-STARBANKING
+//
+//  Created by 이세민 on 5/16/25.
+//
+
+import UIKit
+
+import SnapKit
+
+class AccountInfo: UIView {
+    
+    private let accountNameLabel: UILabel = {
+        let label = UILabel()
+        label.text = "KB내맘대로적금"
+        label.font = .font(.body1_16_light)
+        label.textColor = .color(.kbBlack)
+        return label
+    }()
+    
+    private let editIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .icPencil
+        return imageView
+    }()
+    
+    private let accountNumberLabel: UILabel = {
+        let label = UILabel()
+        label.text = "016703-04-425292"
+        label.font = .font(.title2_18_semibold)
+        label.textColor = .color(.kbBlack)
+        return label
+    }()
+    
+    private let settingButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.icSettings, for: .normal)
+        return button
+    }()
+    
+    private let balanceLabel: UILabel = {
+        let label = UILabel()
+        let number = "10,000", unit = " 원"
+        let fullText = number + unit
+        let attributedText = NSMutableAttributedString(string: fullText)
+        attributedText.addAttributes([.font: UIFont.font(.title1_24_light)], range: NSRange(location: 0, length: fullText.count))
+        attributedText.addAttribute(.font, value: UIFont.font(.title1_24_semibold), range: NSRange(location: 0, length: number.count))
+        label.attributedText = attributedText
+        return label
+    }()
+    
+    private let ddaylabel: UILabel = {
+        let label = UILabel()
+        label.text = "D-183"
+        label.font = .font(.caption3_11_medium)
+        label.textAlignment = .center
+        label.backgroundColor = .color(.gray8)
+        label.textColor = .kbWhite
+        label.clipsToBounds = true
+        label.layer.cornerRadius = 11
+        return label
+    }()
+    
+    private let expirationDateProgressView: UIProgressView = {
+        let progressView = UIProgressView()
+        progressView.progressTintColor = .color(.yellow3)
+        progressView.trackTintColor = .color(.gray1)
+        progressView.progress = 0.3
+        progressView.layer.borderColor = UIColor.color(.gray4).cgColor
+        progressView.layer.cornerRadius = 5
+        progressView.layer.borderWidth = 1
+        progressView.clipsToBounds = true
+        return progressView
+    }()
+    
+    private let newDateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "신규일 2025.04.23"
+        label.font = .font(.caption2_12_light)
+        label.textColor = .color(.gray6)
+        return label
+    }()
+    
+    private let expirationDateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "만기일 2025.10.23"
+        label.font = .font(.caption2_12_light)
+        label.textColor = .color(.gray6)
+        return label
+    }()
+    
+    private let depositButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("입금", for: .normal)
+        button.setTitleColor(.color(.kbBlack), for: .normal)
+        button.titleLabel?.font = .font(.body3_14_light)
+        button.backgroundColor = .color(.gray3)
+        button.layer.cornerRadius = 2
+        button.clipsToBounds = true
+        return button
+    }()
+    
+    private let expectClosingButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("해지예상조회", for: .normal)
+        button.setTitleColor(.color(.kbBlack), for: .normal)
+        button.titleLabel?.font = .font(.body3_14_light)
+        button.backgroundColor = .color(.gray3)
+        button.layer.cornerRadius = 2
+        button.clipsToBounds = true
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setStyle(){
+        self.backgroundColor = .color(.kbWhite)
+    }
+    
+    private func setUI() {
+        addSubviews(
+            accountNameLabel,
+            editIconView,
+            accountNumberLabel,
+            settingButton,
+            balanceLabel,
+            ddaylabel,
+            expirationDateProgressView,
+            newDateLabel,
+            expirationDateLabel,
+            depositButton,
+            expectClosingButton
+        )
+    }
+    
+    private func setLayout() {
+        accountNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
+        editIconView.snp.makeConstraints {
+            $0.centerY.equalTo(accountNameLabel)
+            $0.leading.equalTo(accountNameLabel.snp.trailing)
+            $0.size.equalTo(24)
+        }
+        
+        accountNumberLabel.snp.makeConstraints {
+            $0.top.equalTo(accountNameLabel.snp.bottom).offset(6)
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
+        settingButton.snp.makeConstraints {
+            $0.top.equalTo(accountNameLabel.snp.centerY)
+            $0.trailing.equalToSuperview().offset(-20)
+            $0.size.equalTo(25)
+        }
+        
+        balanceLabel.snp.makeConstraints {
+            $0.top.equalTo(accountNumberLabel.snp.bottom).offset(50)
+            $0.trailing.equalToSuperview().offset(-20)
+        }
+        
+        ddaylabel.snp.makeConstraints {
+            $0.top.equalTo(balanceLabel.snp.bottom).offset(42)
+            $0.leading.equalToSuperview().offset(20)
+            $0.width.equalTo(48)
+            $0.height.equalTo(21)
+        }
+        
+        expirationDateProgressView.snp.makeConstraints {
+            $0.top.equalTo(ddaylabel.snp.bottom).offset(5)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(327)
+            $0.height.equalTo(10)
+        }
+        
+        newDateLabel.snp.makeConstraints {
+            $0.top.equalTo(expirationDateProgressView.snp.bottom).offset(12)
+            $0.leading.equalTo(expirationDateProgressView.snp.leading)
+        }
+        
+        expirationDateLabel.snp.makeConstraints {
+            $0.centerY.equalTo(newDateLabel)
+            $0.trailing.equalTo(expirationDateProgressView.snp.trailing)
+        }
+        
+        depositButton.snp.makeConstraints {
+            $0.top.equalTo(expirationDateLabel.snp.bottom).offset(30)
+            $0.leading.equalToSuperview().offset(20)
+            $0.width.equalTo(164)
+            $0.height.equalTo(38)
+        }
+        
+        expectClosingButton.snp.makeConstraints {
+            $0.top.equalTo(expirationDateLabel.snp.bottom).offset(30)
+            $0.trailing.equalToSuperview().offset(-20)
+            $0.width.equalTo(164)
+            $0.height.equalTo(38)
+        }
+    }
+}

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
@@ -15,7 +15,7 @@ class PrimeRate: UIView {
         let label = UILabel()
         label.text = "현재 적용 중인 우대금리는\n연 6.00%에요"
         label.font = .font(.subtitle1_18_light)
-        label.textColor = .color(.kbBlack)
+        label.textColor = .kbBlack
         label.numberOfLines = 2
         return label
     }()
@@ -24,7 +24,7 @@ class PrimeRate: UIView {
         let label = UILabel()
         label.text = "25년 10월 23일까지 123,900원 모을 수 있어요.\n해당 상품의 최고 적용금리는 연 8.00%입니다."
         label.font = .font(.body3_14_light)
-        label.textColor = .color(.gray6)
+        label.textColor = .gray6
         label.numberOfLines = 2
         return label
     }()
@@ -41,13 +41,13 @@ class PrimeRate: UIView {
         let label = UILabel()
         label.text = "1회차"
         label.font = .font(.body2_15_semibold)
-        label.textColor = .color(.kbBlack)
+        label.textColor = .kbBlack
         return label
     }()
     
     private let firstDividerView: UIView = {
         let view = UIView()
-        view.layer.borderColor = UIColor.color(.gray5).cgColor
+        view.layer.borderColor = UIColor.gray5.cgColor
         view.layer.borderWidth = 1
         return view
     }()
@@ -55,14 +55,14 @@ class PrimeRate: UIView {
     private let dateLabel: UILabel = {
         let label = UILabel()
         label.text = "2025.04월분"
-        label.textColor = .color(.gray6)
+        label.textColor = .gray6
         label.font = .font(.body3_14_medium)
         return label
     }()
     
     private let paymentBottomView: UIView = {
         let view = UIView()
-        view.backgroundColor = .color(.gray1)
+        view.backgroundColor = .gray1
         view.layer.cornerRadius = 10
         view.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         return view
@@ -79,14 +79,14 @@ class PrimeRate: UIView {
     private let placeLabel: UILabel = {
         let label = UILabel()
         label.text = "돈암동"
-        label.textColor = .color(.gray6)
+        label.textColor = .gray6
         label.font = .font(.body3_14_light)
         return label
     }()
     
     private let secondDividerView: UIView = {
         let view = UIView()
-        view.layer.borderColor = UIColor.color(.gray5).cgColor
+        view.layer.borderColor = UIColor.gray5.cgColor
         view.layer.borderWidth = 1
         return view
     }()
@@ -103,7 +103,7 @@ class PrimeRate: UIView {
         let label = UILabel()
         label.text = "*놓치고 있는 금리가 있어요!"
         label.font = .font(.body3_14_medium)
-        label.textColor = .color(.kbBlack)
+        label.textColor = .kbBlack
         return label
     }()
     
@@ -117,7 +117,7 @@ class PrimeRate: UIView {
         let label = UILabel()
         label.text = "*최고 적용금리 8.00% = 기본금리 2.50% + 퀴즈 풀이 시 5.50%p"
         label.font = .font(.caption2_12_light)
-        label.textColor = .color(.gray6)
+        label.textColor = .gray6
         return label
     }()
     
@@ -135,7 +135,7 @@ class PrimeRate: UIView {
     }
     
     private func setStyle(){
-        self.backgroundColor = .color(.kbWhite)
+        self.backgroundColor = .kbWhite
     }
     
     private func setUI() {
@@ -255,12 +255,12 @@ class PrimeRate: UIView {
             let titleLabel = UILabel()
             titleLabel.text = title
             titleLabel.font = .font(.body2_15_light)
-            titleLabel.textColor = .color(.gray6)
+            titleLabel.textColor = .gray6
             
             let valueLabel = UILabel()
             valueLabel.text = value
             valueLabel.font = .font(.body2_15_regular)
-            valueLabel.textColor = .color(.kbBlack)
+            valueLabel.textColor = .kbBlack
             valueLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
             
             hStack.addArrangedSubview(titleLabel)
@@ -269,5 +269,4 @@ class PrimeRate: UIView {
             paymentStackView.addArrangedSubview(hStack)
         }
     }
-    
 }

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
@@ -29,6 +29,76 @@ class PrimeRate: UIView {
         return label
     }()
     
+    private let paymentTopView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray3
+        view.layer.cornerRadius = 10
+        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        return view
+    }()
+    
+    private let countLabel: UILabel = {
+        let label = UILabel()
+        label.text = "1회차"
+        label.font = .font(.body2_15_semibold)
+        label.textColor = .color(.kbBlack)
+        return label
+    }()
+    
+    private let firstDividerView: UIView = {
+        let view = UIView()
+        view.layer.borderColor = UIColor.color(.gray5).cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+    
+    private let dateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "2025.04월분"
+        label.textColor = .color(.gray6)
+        label.font = .font(.body3_14_medium)
+        return label
+    }()
+    
+    private let paymentBottomView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .color(.gray1)
+        view.layer.cornerRadius = 10
+        view.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        return view
+    }()
+    
+    private let paymentStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fillEqually
+        stackView.spacing = 11
+        return stackView
+    }()
+    
+    private let placeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "돈암동"
+        label.textColor = .color(.gray6)
+        label.font = .font(.body3_14_light)
+        return label
+    }()
+    
+    private let secondDividerView: UIView = {
+        let view = UIView()
+        view.layer.borderColor = UIColor.color(.gray5).cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+    
+    private let newLabel: UILabel = {
+        let label = UILabel()
+        label.text = "신규"
+        label.textColor = .gray6
+        label.font = .font(.body3_14_light)
+        return label
+    }()
+    
     private let suggestionLabel: UILabel = {
         let label = UILabel()
         label.text = "*놓치고 있는 금리가 있어요!"
@@ -50,13 +120,14 @@ class PrimeRate: UIView {
         label.textColor = .color(.gray6)
         return label
     }()
-   
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setStyle()
         setUI()
         setLayout()
+        setPaymentItems()
     }
     
     required init?(coder: NSCoder) {
@@ -71,10 +142,16 @@ class PrimeRate: UIView {
         addSubviews(
             descriptionLabel,
             subDescriptionLabel,
+            paymentTopView,
+            paymentBottomView,
+            
             suggestionLabel,
             suggestionButton,
             referenceLabel
         )
+        
+        paymentTopView.addSubviews(countLabel, firstDividerView, dateLabel)
+        paymentBottomView.addSubviews(paymentStackView,  placeLabel, secondDividerView, newLabel)
     }
     
     private func setLayout() {
@@ -86,6 +163,60 @@ class PrimeRate: UIView {
         subDescriptionLabel.snp.makeConstraints {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(8)
             $0.leading.equalToSuperview().offset(20)
+        }
+        
+        paymentTopView.snp.makeConstraints {
+            $0.top.equalTo(subDescriptionLabel.snp.bottom).offset(18)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(335)
+            $0.height.equalTo(44)
+        }
+        
+        countLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
+        firstDividerView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(countLabel.snp.trailing).offset(9)
+            $0.width.equalTo(1)
+            $0.height.equalTo(15)
+        }
+        
+        dateLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(firstDividerView.snp.trailing).offset(9)
+        }
+        
+        paymentBottomView.snp.makeConstraints {
+            $0.top.equalTo(paymentTopView.snp.bottom)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(335)
+            $0.height.equalTo(220)
+        }
+        
+        paymentStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(14)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(154)
+        }
+        
+        placeLabel.snp.makeConstraints {
+            $0.top.equalTo(paymentStackView.snp.bottom).offset(16)
+            $0.trailing.equalTo(secondDividerView.snp.leading).offset(-9)
+        }
+        
+        secondDividerView.snp.makeConstraints {
+            $0.centerY.equalTo(placeLabel)
+            $0.trailing.equalTo(newLabel.snp.leading).offset(-9)
+            $0.width.equalTo(1)
+            $0.height.equalTo(15)
+        }
+        
+        newLabel.snp.makeConstraints {
+            $0.centerY.equalTo(placeLabel)
+            $0.trailing.equalToSuperview().offset(-20)
         }
         
         suggestionLabel.snp.makeConstraints {
@@ -105,4 +236,38 @@ class PrimeRate: UIView {
             $0.leading.equalToSuperview().offset(20)
         }
     }
+    
+    private func setPaymentItems() {
+        let items: [(String, String)] = [
+            ("납입일자", "2025.04.23"),
+            ("납입금액", "10,000 원"),
+            ("납입 후 잔액", "10,000 원"),
+            ("적금방식", "1일 1회 직접 입금"),
+            ("적용금리", "연 6.00%")
+        ]
+        
+        items.forEach { title, value in
+            let hStack = UIStackView()
+            hStack.axis = .horizontal
+            hStack.distribution = .equalSpacing
+            hStack.widthAnchor.constraint(equalToConstant: 295).isActive = true
+            
+            let titleLabel = UILabel()
+            titleLabel.text = title
+            titleLabel.font = .font(.body2_15_light)
+            titleLabel.textColor = .color(.gray6)
+            
+            let valueLabel = UILabel()
+            valueLabel.text = value
+            valueLabel.font = .font(.body2_15_regular)
+            valueLabel.textColor = .color(.kbBlack)
+            valueLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+            
+            hStack.addArrangedSubview(titleLabel)
+            hStack.addArrangedSubview(valueLabel)
+            
+            paymentStackView.addArrangedSubview(hStack)
+        }
+    }
+    
 }

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
@@ -1,0 +1,108 @@
+//
+//  PrimeRate.swift
+//  KB-STARBANKING
+//
+//  Created by 이세민 on 5/16/25.
+//
+
+import UIKit
+
+import SnapKit
+
+class PrimeRate: UIView {
+    
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "현재 적용 중인 우대금리는\n연 6.00%에요"
+        label.font = .font(.subtitle1_18_light)
+        label.textColor = .color(.kbBlack)
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    private let subDescriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "25년 10월 23일까지 123,900원 모을 수 있어요.\n해당 상품의 최고 적용금리는 연 8.00%입니다."
+        label.font = .font(.body3_14_light)
+        label.textColor = .color(.gray6)
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    private let suggestionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "*놓치고 있는 금리가 있어요!"
+        label.font = .font(.body3_14_medium)
+        label.textColor = .color(.kbBlack)
+        return label
+    }()
+    
+    private let suggestionButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.imgBanner, for: .normal)
+        return button
+    }()
+    
+    private let referenceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "*최고 적용금리 8.00% = 기본금리 2.50% + 퀴즈 풀이 시 5.50%p"
+        label.font = .font(.caption2_12_light)
+        label.textColor = .color(.gray6)
+        return label
+    }()
+   
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setStyle(){
+        self.backgroundColor = .color(.kbWhite)
+    }
+    
+    private func setUI() {
+        addSubviews(
+            descriptionLabel,
+            subDescriptionLabel,
+            suggestionLabel,
+            suggestionButton,
+            referenceLabel
+        )
+    }
+    
+    private func setLayout() {
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(38)
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
+        subDescriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(8)
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
+        suggestionLabel.snp.makeConstraints {
+            $0.top.equalTo(subDescriptionLabel.snp.bottom).offset(320)
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
+        suggestionButton.snp.makeConstraints {
+            $0.top.equalTo(suggestionLabel.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(335)
+            $0.height.equalTo(54)
+        }
+        
+        referenceLabel.snp.makeConstraints {
+            $0.top.equalTo(suggestionButton.snp.bottom).offset(10)
+            $0.leading.equalToSuperview().offset(20)
+        }
+    }
+}

--- a/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
+++ b/KB-STARBANKING/KB-STARBANKING/Presentation/Transaction/View/PrimeRate.swift
@@ -258,10 +258,17 @@ class PrimeRate: UIView {
             titleLabel.textColor = .gray6
             
             let valueLabel = UILabel()
-            valueLabel.text = value
             valueLabel.font = .font(.body2_15_regular)
-            valueLabel.textColor = .kbBlack
             valueLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+            
+            if title == "납입금액", let range = value.range(of: "10,000") {
+                let attributed = NSMutableAttributedString(string: value)
+                attributed.addAttribute(.foregroundColor, value: UIColor.blue1, range: NSRange(range, in: value))
+                valueLabel.attributedText = attributed
+            } else {
+                valueLabel.text = value
+                valueLabel.textColor = .kbBlack
+            }
             
             hStack.addArrangedSubview(titleLabel)
             hStack.addArrangedSubview(valueLabel)


### PR DESCRIPTION
## 📟 연결된 이슈
closed #8 

## 👷 작업한 내용
- TransactionViewController 내에 AccountInfo View와 PrimeRate View로 나눠 구현했습니다.
- API 연동 전 모든 데이터를 하드코딩한 상태입니다.
- 최상단 부분을 NavigationView로 임시 분리했습니다.

## 📸 스크린샷
<img src = "https://github.com/user-attachments/assets/1a471e18-6d46-444d-8554-4599322674bc" width ="250">
